### PR TITLE
Update task actions to use API

### DIFF
--- a/app/dashboard/components/EditTaskModal.tsx
+++ b/app/dashboard/components/EditTaskModal.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 
 import { taskSchema, Task } from "@/lib/validators/task";
 import { useTaskStore } from "@/lib/store/taskStore";
+import { useTasks } from "@/lib/hooks/useTasks";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -28,7 +29,8 @@ import {
 export default function EditTaskModal() {
   const editingTask = useTaskStore((state) => state.editingTask);
   const setEditingTask = useTaskStore((state) => state.setEditingTask);
-  const updateTask = useTaskStore((state) => state.updateTask);
+  const updateLocalTask = useTaskStore((state) => state.updateTask);
+  const { updateTask } = useTasks();
 
   const form = useForm<Task>({
     resolver: zodResolver(taskSchema),
@@ -45,7 +47,8 @@ export default function EditTaskModal() {
   if (!editingTask) return null;
 
   const onSubmit = (data: Task) => {
-    updateTask(data);
+    updateLocalTask(data); // optimistic update
+    updateTask.mutate(data);
     setEditingTask(null);
   };
 

--- a/app/dashboard/components/TaskCard.tsx
+++ b/app/dashboard/components/TaskCard.tsx
@@ -2,6 +2,7 @@
 
 import { Task } from "@/lib/validators/task";
 import { useTaskStore } from "@/lib/store/taskStore";
+import { useTasks } from "@/lib/hooks/useTasks";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -16,12 +17,14 @@ import {
 import { useState } from "react";
 
 export default function TaskCard({ task }: { task: Task }) {
-  const { setEditingTask, deleteTask } = useTaskStore();
+  const { setEditingTask, deleteTask: deleteFromStore } = useTaskStore();
+  const { deleteTask } = useTasks();
   const [open, setOpen] = useState(false);
 
   const handleDelete = () => {
     if (task.id) {
-      deleteTask(task.id); // Zustand delete
+      deleteFromStore(task.id); // optimistic update
+      deleteTask.mutate(task.id);
       setOpen(false);
     }
   };


### PR DESCRIPTION
## Summary
- connect TaskCard delete action to React Query API
- connect EditTaskModal save to API via React Query

## Testing
- `npm install`
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68546371a1388325b8bdbebdd48b4b16